### PR TITLE
Port extension to Nautilus 43

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ nautilus -q
 The following packages are required to build win32-details:
 
 * **Python** >= 3.6,
-* Probably a recent version of **Nautilus 3.x**, or **Nautilus <= 42.x**,
+* A recent version of **Nautilus >= 43.x**,
 * [nautilus-python](https://wiki.gnome.org/Projects/NautilusPython),
 * Copy of [exiftool](https://github.com/exiftool/exiftool) (required by PyExifTool),
 * [PyExifTool](https://pypi.org/project/PyExifTool/)

--- a/README.md
+++ b/README.md
@@ -87,6 +87,14 @@ Close currently opened Nautilus instances to load the extension:
 nautilus -q
 ```
 
+## Note about Nautilus versions below 43.x
+Support for older Nautilus versions has been removed in win32-details 0.5.0, because of moving to Nautilus API 4.0, which deprecates direct usage of GTK widgets in favor of a new model-based interface (which is a shitty decision IMO). In this situation I had three options:
+- Maintain both versions of extension, one for Nautilus 43 and above, and one for Nautilus <= 42,
+- Make this extension as a standalone program, and use extension to launch it,
+- Just deprecate support for older Nautilus versions.
+
+Honestly, I'm not that interested in maintaining a seperate version of extension, as majority of people are using the latest version of Nautilus now. Moving a extension to a standalone program would make everything more complicated, and I don't think that many people would want to install an app which just shows them details of EXE files (but maybe, in the [future](https://github.com/tfuxu/win32-details/issues/5)...).
+
 ## License
 <p>
 <img src="https://www.gnu.org/graphics/gplv3-with-text-136x68.png" alt="GPLv3 logo" align="right">
@@ -94,10 +102,14 @@ This repository is licensed under the terms of the GNU GPLv3 license. You can fi
 </p>
 
 ## Changelog
-* **0.4:**
+* **0.5.0:**
+    * Port extension to Nautilus API 4.0, **from this version onward, win32-details won't support Nautilus versions below 43**[ (more info)](#note-about-nautilus-versions-below-43x)
+    * Add new Meson build option
+    * Change page name to `More Properties`
+* **0.4.0:**
     * Add a `MD5 Hash` row
     * Allow user to copy values from rows (if row is selected, click left one time to select text)
     * Add setup.py for packaging to PyPI
     * Create a small CLI tool for easier installing (based on [Nautilus Terminal](https://github.com/flozz/nautilus-terminal/blob/master/nautilus_terminal/__main__.py))
-* **0.1:**
+* **0.1.0:**
     * Initial release of Win32 Details

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('win32-details',
-        version: '0.4',
+        version: '0.5.0',
         meson_version: '>= 0.59.0',
         default_options: [ 'warning_level=2',
                            'werror=false',

--- a/meson.build
+++ b/meson.build
@@ -13,14 +13,17 @@ python = import('python')
 EXTENSIONS_DIR = join_paths(get_option('prefix'), get_option('datadir'), 'nautilus-python/extensions')
 
 dependency('glib-2.0')
-dependency('gtk+-3.0')
-dependency('pygobject-3.0', version: '>= 3.40.0')
+dependency('gtk4')
+dependency('pygobject-3.0', version: '>= 3.42.0')
 
 # Check if python3 is installed
 PY_INSTALLDIR = python.find_installation('python3', required: true)
 
 # Check if exiftool is installed
 find_program('exiftool', required: true)
+
+# Check if Nautilus 43 is installed
+find_program('nautilus', version: '>= 43.0', required: true)
 
 # Install configuration data
 conf = configuration_data()

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open("README.md", "r", encoding="utf-8") as f:
 setup(
     name="win32-details",
     license="GPL-3.0",
-    version="0.4.0",
+    version="0.5.0",
     author="tfuxu",
     description=".exe file details for your Nautilus file browser",
     long_description=long_desc,

--- a/win32_details/__init__.py
+++ b/win32_details/__init__.py
@@ -4,4 +4,4 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 
-VERSION = "0.4.0"
+VERSION = "0.5.0"


### PR DESCRIPTION
Port `win32-details` to Nautilus API 4.0, to support Nautilus 43.
This change deprecates support for older Nautilus versions, which has been addressed in a new section in `README.md`.